### PR TITLE
Fix static TLS null division

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ project(elf-loader C CXX ASM)
 
 cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
 
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 macro(add_cflags)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${ARGN}")
 endmacro(add_cflags)


### PR DESCRIPTION
Hello, that's first crash I've encountered playing with android x86_64 binaries. None of them have PT_TLS phdr, thus tls_align was always 0.

Only change in vdl-tls.c:111 should be necessary to fix my issue, yet I've tried to ensure that we set this alignment to 1.

Wonder if vdl_utils_align_up should be adjusted to handle 0 alignment as 1, but for now I went with such more local fix.

Additionally previous commit fixes builddir != sourcedir case for me.